### PR TITLE
8.4 throwable nullable signature deprecation fix

### DIFF
--- a/szamlaagent/src/SzamlaAgent/SzamlaAgentException.php
+++ b/szamlaagent/src/SzamlaAgent/SzamlaAgentException.php
@@ -45,7 +45,7 @@ class SzamlaAgentException extends \Exception {
      * @param int        $code
      * @param \Exception $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null) {
+    public function __construct($message, $code = 0, ?\Throwable $previous = null) {
         parent::__construct($message, $code, $previous);
     }
 


### PR DESCRIPTION
Php 8.4 throws this deprecation warning, this fix hopefully won't break earlier php versions, but fixes the deprecation in 8.4.


`Deprecated: SzamlaAgent\SzamlaAgentException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/benjaminhu/szamlazz-php-api/szamlaagent/src/SzamlaAgent/SzamlaAgentException.php on line 48`